### PR TITLE
Generate bahn.expert details link based on trip_id for DBRIS

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -15,4 +15,5 @@ requires 'Travel::Status::DE::EFA',              '>= 3.09';
 requires 'Travel::Status::DE::HAFAS',            '>= 5.06';
 requires 'Travel::Status::DE::IRIS';
 requires 'Travel::Status::MOTIS';
+requires 'URI::Escape';
 requires 'XML::LibXML';

--- a/templates/_train_details.html.ep
+++ b/templates/_train_details.html.ep
@@ -155,7 +155,9 @@
         <a class="smallbutton" href="/carriage-formation?<%= $departure->{wr_link} %>&amp;e=<%= $departure->{wr_direction} // '' %>"><i class="material-icons" aria-hidden="true">train</i> <%= $departure->{wr_text} || 'Wagen' %>
         </a>
 %     }
-%     if ($departure->{train_type} and $departure->{train_no} and (not param('hafas') or param('hafas') eq 'DB')) {
+%     if ($departure->{trip_id} and param('dbris') eq 'bahn.de') {
+        <a class="smallbutton" href="https://bahn.expert/details/x/h/<%= URI::Escape::uri_escape( $departure->{trip_id} ) %>"><img src="/static/icons/bahn-expert.svg">Details</a>
+%     } elsif ($departure->{train_type} and $departure->{train_no} and (not param('hafas') or param('hafas') eq 'DB')) {
         <a class="smallbutton" href="https://bahn.expert/details/<%= $departure->{train_type} %>%20<%= $departure->{train_no} %>/<%= ($departure->{date} // DateTime->now(time_zone => 'Europe/Berlin'))->iso8601 %>?evaNumberAlongRoute=<%= $departure->{eva} %>"><img src="/static/icons/bahn-expert.svg">Details</a>
 %     }
 %     for my $link (@{$departure->{links}}) {


### PR DESCRIPTION
This pull request adds a conditional for the train details page to generate the bahn.expert details outlink based on the trip_id when using DBRIS bahn.de.

This is a lot more reliable compared to concating category and train number / date. As bahn.expert recently added support for resolving these HAFAS trip ids to RIS::Journey journeys, the data quality is also on par.

See https://chaos.social/@marudor/114404980599765615