### PR TITLE
Allow running docker image as arbitrary user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ RUN apt-get update \
 	&& rm -rf /var/cache/apt/* /var/lib/apt/lists/*
 
 COPY --from=files /app/ /app/
+RUN chmod -R a+rX /app
 
 EXPOSE 8092
 


### PR DESCRIPTION
Thanks for the great piece of software!

This PR allows running the docker image rootless, such as when running using `docker run --user 1234 ...`. This is a defense-in-depth security measure and required in some setups, see https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html#rule-2-set-a-user